### PR TITLE
Fix failed dapperdox download due to old ca-certs

### DIFF
--- a/doc/Dockerfile
+++ b/doc/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.8
 
 WORKDIR /opt/app/dapperdox
 


### PR DESCRIPTION
### What

Update the alpine base docker image to get more up to date ca-certificates in order to fix failed TLS connection when downloading dapperdox tar.

### How to review

Ensure the docker image now builds.

### Who can review

Anyone but me.
