### PR TITLE
Fix nomad deployment not deploying new versions

### DIFF
--- a/doc/dp-developer-poc.nomad
+++ b/doc/dp-developer-poc.nomad
@@ -43,7 +43,7 @@ job "dp-developer-poc" {
           "-bind-addr=:8080",
         ]
 
-        image = "{{ECR_URL}}:latest"
+        image = "{{ECR_URL}}:concourse-{{REVISION}}"
 
         port_map {
           http = 8080
@@ -54,6 +54,12 @@ job "dp-developer-poc" {
         name = "dp-developer-poc"
         port = "http"
         tags = ["web"]
+        check {
+          type     = "http"
+          path     = "/"
+          interval = "10s"
+          timeout  = "2s"
+        }
       }
 
       resources {

--- a/dp-api-poc.nomad
+++ b/dp-api-poc.nomad
@@ -38,7 +38,7 @@ job "dp-api-poc" {
 
         args = ["dp-apipoc-server"]
 
-        image = "{{ECR_URL}}:latest"
+        image = "{{ECR_URL}}:concourse-{{REVISION}}"
 
         port_map {
           http = 8080


### PR DESCRIPTION
### What

The nomad deployment was hardcoded to `latest` docker tag, but we use
commit sha for the versions. This was causing an old version to be
deployed always and ignoring new commits.

Also added a rudimentary health check for the developer poc that will
just test that `/` is accessible.

### Who can review

Anyone but me.
