### PR TITLE
Fix command not found on Nomad deploy

### DIFF
--- a/dp-api-poc.nomad
+++ b/dp-api-poc.nomad
@@ -36,7 +36,7 @@ job "dp-api-poc" {
       config {
         command = "${NOMAD_TASK_DIR}/start-task"
 
-        args = ["dp-apipoc-server"]
+        args = ["./dp-api-poc"]
 
         image = "{{ECR_URL}}:concourse-{{REVISION}}"
 


### PR DESCRIPTION
### What

The binary name in the nomad plan was incorrect resulting in an error
when starting the docker container via Nomad:

```
dp-api-poc: command not found
```

The correct binary name can be seen in the Makefile for comparison when reviewing.

### Who can review

Anyone but me.
